### PR TITLE
Upgraded compatibility to Manus SDK version 2.5.1

### DIFF
--- a/ManusGlove/CMakeLists.txt
+++ b/ManusGlove/CMakeLists.txt
@@ -9,10 +9,9 @@ project(YARPManusGlove VERSION "0.0.1"
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-set(ManusGloveLibName "ManusSDK")
 set(ManusGloveDevName "ManusGlove")
 
-find_package(${ManusGloveLibName} REQUIRED)
+find_package(ManusSDK REQUIRED)
 
 # Export all symbols in Windows
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
@@ -50,7 +49,7 @@ target_link_libraries(${ManusGloveDevName}
     IWear::IWear
     PRIVATE
     YARP::YARP_init
-    ${ManusGloveLibName}
+    ManusSDK::ManusSDK
     Eigen3::Eigen
     )
 

--- a/ManusGlove/README.md
+++ b/ManusGlove/README.md
@@ -3,13 +3,12 @@
 # Dependencies
 ### Manus Glove SDK  
 - Download the SDK from https://www.manus-meta.com/resources/downloads/quantum-metagloves
-- Extract the files into a folder and rename it "ManusGlove-API".
-
+- Extract the files into a folder and rename it "ManusGlove-API". The device works only with 2.5.1 version
 - Add following environment variable:
 
 ```bash
-set ManusGlove_DIR=C:\ManusGlove-API\SDKClient\SDKClient
-set PATH=%PATH%:%ManusGlove_DIR%\ManusSDK
+set ManusGlove_DIR=C:\ManusGlove-API\SDKClient\SDKClient_Windows
+set PATH=%PATH%:%ManusGlove_DIR%\ManusSDK\lib
 ```
 ### Manus Core
 - Download and install the Manus Core from [here](https://www.manus-meta.com/resources/downloads/quantum-metagloves).

--- a/ManusGlove/include/ManusGloveHelper.h
+++ b/ManusGlove/include/ManusGloveHelper.h
@@ -317,7 +317,8 @@ protected:
     static ManusVec3 CreateManusVec3(float p_X, float p_Y, float p_Z);
 
 protected:
-    static ManusGloveHelper *s_Instance;
+    static ManusGloveHelper* s_Instance;
+    static std::mutex s_InstanceMutex;
     bool m_Running = true;
     std::string ManusGlove_LogPrefix = "ManusGloveHelper::";
 

--- a/ManusGlove/src/ManusGlove.cpp
+++ b/ManusGlove/src/ManusGlove.cpp
@@ -255,7 +255,12 @@ bool ManusGlove::ManusGloveImpl::open(yarp::os::Searchable& config)
     yInfo() << LogPrefix << "offset vector: " << ss_vector.str();
 
 // TODO: Add a check if there is no glove connected!
-    pGlove->Initialize(hostType);
+    if (!pGlove->Initialize(hostType))
+    {
+        yError() << LogPrefix << "Failed to initialize the ManusGloveHelper on the" << handSideLogPrefix << "hand.";
+        return false;
+    }
+    yInfo() << LogPrefix << "ManusGloveHelper initialized successfully on the" << handSideLogPrefix << "hand.";
 
     if (!pGlove->SetHandJoints(humanJointNameList, handSide))
     {

--- a/ManusGlove/src/ManusGloveHelper.cpp
+++ b/ManusGlove/src/ManusGloveHelper.cpp
@@ -29,7 +29,7 @@ bool ManusGloveHelper::Initialize(bool p_hostType)
     m_ShouldConnectLocally = p_hostType;
     // before we can use the SDK, some internal SDK bits need to be initialized.
     // however after initializing, the SDK is not yet connected to a host or doing anything network related just yet.
-    if (CoreSdk_Initialize(SessionType::SessionType_CoreSDK) != SDKReturnCode::SDKReturnCode_Success)
+    if (CoreSdk_InitializeCore() != SDKReturnCode::SDKReturnCode_Success)
     {
         yError() << ManusGlove_LogPrefix << "SDK::Failed to initilize Core SDK.";
         return false;
@@ -857,8 +857,12 @@ std::string ManusGloveHelper::ConvertDeviceFamilyTypeToString(DeviceFamilyType p
         return "Prime 2";
     case DeviceFamilyType_PrimeX:
         return "Prime X";
-    case DeviceFamilyType_Quantum:
-        return "Quantum";
+    case DeviceFamilyType_Metaglove:
+        return "Metaglove";
+    case DeviceFamilyType_MetaglovePro:
+        return "Metaglove Pro";
+    case DeviceFamilyType_MetagloveProPrecision:
+        return "Metaglove Pro Precision";
     case DeviceFamilyType_Prime3:
         return "Prime 3";
     case DeviceFamilyType_Virtual:

--- a/cmake/FindManusSDK.cmake
+++ b/cmake/FindManusSDK.cmake
@@ -1,46 +1,21 @@
 # SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Finds the Manus Glove SDK
-#
-# This will define the following variables::
-#
-#   ManusGlove_FOUND         - True if the system has the Manus Glove SDK
-#   ManusGlove               - The name of the libraries to link against.
-###############################
+include(FindPackageHandleStandardArgs)
 
-# Check Directory of the ManusGlove_DIR
-if(NOT DEFINED ENV{ManusGlove_DIR})
-  message( FATAL_ERROR "Environment variable {ManusGlove_DIR} is not defined." )
-else()
-  message(STATUS "Environment variable {ManusGlove_DIR}: $ENV{ManusGlove_DIR}" )
+set(MANUS_ROOT_DIR "$ENV{ManusGlove_DIR}" CACHE PATH "Folder containing the ManusSDK")
+
+find_path(MANUS_INCLUDE_DIR ManusSDK.h PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK/include)
+find_library(MANUS_LIBRARY ManusSDK PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK ManusSDK/lib)
+
+find_package_handle_standard_args(ManusSDK DEFAULT_MSG MANUS_INCLUDE_DIR MANUS_LIBRARY)
+
+if(ManusSDK_FOUND)
+    if(NOT TARGET ManusSDK::ManusSDK)
+      add_library(ManusSDK::ManusSDK UNKNOWN IMPORTED)
+      set_target_properties(ManusSDK::ManusSDK PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${MANUS_INCLUDE_DIR}")
+      set_property(TARGET ManusSDK::ManusSDK APPEND PROPERTY
+        IMPORTED_LOCATION "${MANUS_LIBRARY}")
+    endif()
 endif()
-
-if (CMAKE_BUILD_TYPE MATCHES "Debug")
-  set(BUILD_TYPE "Debug")
-else()
-  set(BUILD_TYPE "Release")
-endif()
-message(STATUS "ManusGlove is linking to BUILD_TYPE: ${BUILD_TYPE}")
-
-
-if(WIN32)
-  file(GLOB ManusGlove_LIB $ENV{ManusGlove_DIR}/ManusSDK/ManusSDK.lib )
-  set(LIB_TYPE "STATIC")
-else()
-  file(GLOB ManusGlove_LIB $ENV{ManusGlove_DIR}/ManusSDK/ManusSDK.so )
-  set(LIB_TYPE "SHARED")
-endif()
-
-set(ManusGlove_INCLUDE_DIRS $ENV{ManusGlove_DIR} )
-
-message(STATUS "Variable {ManusGlove_LIB}: ${ManusGlove_LIB}" )
-message(STATUS "variable {ManusGlove_INCLUDE_DIRS}: ${ManusGlove_INCLUDE_DIRS}" )
-
-##### Find ManusGlove #####
-
-add_library(ManusSDK ${LIB_TYPE} IMPORTED GLOBAL ${ManusGlove_LIB})
-set_target_properties(ManusSDK PROPERTIES IMPORTED_LOCATION ${ManusGlove_LIB})
-target_include_directories(ManusSDK INTERFACE ${ManusGlove_INCLUDE_DIRS})
-
-set(ManusGlove_FOUND TRUE)


### PR DESCRIPTION
Fixes #8 

The first commit makes the code compatible with the 2.5.1 SDK version.

It is compatible also with the 3.0.0, but they changed the policy for the license, and it would be needed a USB key we do not have at the moment.

While testing, I noticed a weird error during the initialization. Digging into it, it appeared that when using two gloves, the SDK was initialized twice, and it triggered the error. The code was still working because all the data is stored in a static instance. The second commit avoids raising the error