### PR TITLE
Add support for Ubuntu 22.04

### DIFF
--- a/ManusGlove/README.md
+++ b/ManusGlove/README.md
@@ -6,9 +6,8 @@
 Download the `SDK` and `MANUS Core 2 Online` from https://docs.manus-meta.com/latest/Resources/. The device is tested with the `2.5.1` version.
 Create a folder named `"ManusGlove-API"`, and extract the files inside the folder.
 
-To install the device, it is highly suggested to do it via the [robotology-superbuild](https://github.com/robotology/robotology-superbuild).
-Before doing so, make sure to export the following environment variables:
-```bash
+Before building and installing the device, make sure to export the following environmental variables:
+```
 set ManusGlove_DIR=C:\ManusGlove-API\SDKClient\SDKClient_Windows
 set PATH=%PATH%;%ManusGlove_DIR%\ManusSDK\lib
 ```

--- a/ManusGlove/README.md
+++ b/ManusGlove/README.md
@@ -15,7 +15,7 @@ set PATH=%PATH%;%ManusGlove_DIR%\ManusSDK\lib
 
 
 ## Linux
-Download the `SDK` from https://docs.manus-meta.com/latest/Resources/. The device is tested only with Manus SDK **Version v3.** (with the newer gloves) and Ubuntu 22.04. However, `ManusCore` is not available: instead, we launch `ManusIntegrated`.
+Download the `SDK` from https://docs.manus-meta.com/latest/Resources/. The device is tested only with Manus SDK **Version v3.** (with the `Metagloves Pro`) and Ubuntu 22.04. However, `ManusCore` is not available: instead, we launch `ManusIntegrated`.
 
 For the dependencies, you can refer to https://docs.manus-meta.com/latest/Plugins/SDK/Linux/.
 Summarizing, we only need to install the dependencies for Manus `Integrated`, not `Remote`. Launch:

--- a/ManusGlove/README.md
+++ b/ManusGlove/README.md
@@ -7,7 +7,7 @@ Download the `SDK` and `MANUS Core 2 Online` from https://docs.manus-meta.com/la
 Create a folder named `"ManusGlove-API"`, and extract the files inside the folder.
 
 To install the device, it is highly suggested to do it via the [robotology-superbuild](https://github.com/robotology/robotology-superbuild).
-Before doing so, make sure to export the following environemnt variables:
+Before doing so, make sure to export the following environment variables:
 ```bash
 set ManusGlove_DIR=C:\ManusGlove-API\SDKClient\SDKClient_Windows
 set PATH=%PATH%;%ManusGlove_DIR%\ManusSDK\lib

--- a/ManusGlove/README.md
+++ b/ManusGlove/README.md
@@ -1,15 +1,83 @@
 # Dependencies to install and use the Manus Glove Device
 
-# Dependencies
-### Manus Glove SDK  
-- Download the SDK from https://www.manus-meta.com/resources/downloads/quantum-metagloves
-- Extract the files into a folder and rename it "ManusGlove-API". The device works only with 2.5.1 version
-- Add following environment variable:
+# Manus Glove SDK  
 
+## Windows 
+Download the `SDK` and `MANUS Core 2 Online` from https://docs.manus-meta.com/latest/Resources/. The device is tested with the `2.5.1` version.
+Create a folder named `"ManusGlove-API"`, and extract the files inside the folder.
+
+To install the device, it is highly suggested to do it via the [robotology-superbuild](https://github.com/robotology/robotology-superbuild).
+Before doing so, make sure to export the following environemnt variables:
 ```bash
 set ManusGlove_DIR=C:\ManusGlove-API\SDKClient\SDKClient_Windows
 set PATH=%PATH%;%ManusGlove_DIR%\ManusSDK\lib
 ```
-### Manus Core
-- Download and install the Manus Core from [here](https://www.manus-meta.com/resources/downloads/quantum-metagloves).
+
+
+## Linux
+Download the `SDK` from https://docs.manus-meta.com/latest/Resources/. The device is tested only with Manus SDK **Version v3.** (with the newer gloves) and Ubuntu 22.04. However, `ManusCore` is not available: instead, we launch `ManusIntegrated`.
+
+For the dependencies, you can refer to https://docs.manus-meta.com/latest/Plugins/SDK/Linux/.
+Summarizing, we only need to install the dependencies for Manus `Integrated`, not `Remote`. Launch:
+
+```sh
+sudo apt-get update && sudo apt-get install -y build-essential git libtool libzmq3-dev libusb-1.0-0-dev zlib1g-dev libudev-dev gdb libncurses5-dev && sudo apt-get clean
+```
+
+To allow connections to MANUS hardware you need to place the following file in `/etc/udev/rules.d/70-manus-hid-rules`.
+So, run `sudo nano /etc/udev/rules.d/70-manus-hid-rules` and put:
+
+```
+# HIDAPI/libusb
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="3325", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="83fd", MODE:="0666"
+
+# HIDAPI/hidraw
+KERNEL=="hidraw*", ATTRS{idVendor}=="3325", MODE:="0666"
+```
+
+
+Before using the glove, it is highly advisable to perform calibration. In order to do so, you need to build the examples.
+Move to 
+
+```
+cd <PATH_TO>/SDKClient_Linux
+make all LDFLAGS="-L./ManusSDK/lib -lManusSDK_integrated -lncurses -lpthread -Wl,-rpath=./ManusSDK/lib"
+```
+Now you can run:
+```
+./SDKClient_Linux.out 
+```
+
+### Install the device
+
+Export the environmental variables:
+
+```bash
+export ManusGlove_DIR=<PATH_TO>/ManusSDK_v3.1.1/SDKClient_Linux
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ManusGlove_DIR$/ManusSDK/lib
+```
+
+Run `cmake`, make sure to set the right `CMAKE_INSTALL_PREFIX`. If you are using the `superbuild`, point to the superbuild install prefix. 
+If you are using a conda environment, you can use: 
+```bash
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DYARP_DEVICE_MANUS_GLOVE_ENABLE=ON
+```
+
+If you are not using the `superbuild`, build and install:
+
+```bash
+make -j
+make install
+```
+
+### Run the device
+After installation, the `xml` should now be installed in the correct `YARP_DATA_DIRS`.
+You can launch:
+```bash
+yarprobotinterface --config ManusGlove.xml
+```
+
+
 

--- a/ManusGlove/conf/ManusGlove/Left.xml
+++ b/ManusGlove/conf/ManusGlove/Left.xml
@@ -7,6 +7,7 @@
         <param name="wearableName">HapticGlove</param>
         <param name="is_right_hand">false</param>
         <param name="is_local_host">true</param>
+        <param name="use_manus_core">true</param>
         <param name="publish_raw_data">true</param>
         <param name="human_joint_list">( "l_thumb_oppose", "l_thumb_proximal", "l_thumb_middle", "l_thumb_distal",
                                          "l_index_abduction", "l_index_proximal", "l_index_middle", "l_index_distal",

--- a/ManusGlove/conf/ManusGlove/Right.xml
+++ b/ManusGlove/conf/ManusGlove/Right.xml
@@ -7,6 +7,7 @@
         <param name="wearableName">HapticGlove</param>
         <param name="is_right_hand">true</param>
         <param name="is_local_host">true</param>
+        <param name="use_manus_core">true</param>
         <param name="publish_raw_data">true</param>
         <param name="human_joint_list">( "r_thumb_oppose", "r_thumb_proximal", "r_thumb_middle", "r_thumb_distal",
                                          "r_index_abduction", "r_index_proximal", "r_index_middle", "r_index_distal",

--- a/ManusGlove/include/ManusGloveHelper.h
+++ b/ManusGlove/include/ManusGloveHelper.h
@@ -109,8 +109,9 @@ public:
      * @brief Initialize the SDK, register the callbacks and set the coordinate system.
      * This needs to be done before any of the other SDK functions can be used.
      * @param p_hostType if true it looks for hosts only locally, if false it looks for hosts anywhere in the network-name description
+     * @param p_useManusCore if true uses CoreSdk_InitializeCore(), if false uses CoreSdk_InitializeIntegrated()
      */
-    bool Initialize(bool p_hostType);
+    bool Initialize(bool p_hostType, bool p_useManusCore = false);
 
     /**
      * When you are done with the SDK, don't forget to nicely shut it down

--- a/ManusGlove/src/ManusGlove.cpp
+++ b/ManusGlove/src/ManusGlove.cpp
@@ -145,7 +145,7 @@ bool ManusGlove::ManusGloveImpl::open(yarp::os::Searchable& config)
     bool isLocalHost = config.find("is_local_host").asBool();
     hostType = isLocalHost;
 
-    useManusCore = config.check("use_manus_core", yarp::os::Value(false)).asBool();
+    useManusCore = config.check("use_manus_core", yarp::os::Value(true)).asBool();
     yInfo() << LogPrefix << "use_manus_core: " << (useManusCore ? "true" : "false");
 
     // Get Human Joint Names

--- a/ManusGlove/src/ManusGlove.cpp
+++ b/ManusGlove/src/ManusGlove.cpp
@@ -56,6 +56,7 @@ public:
     std::string handSideLogPrefix;
 
     bool hostType;
+    bool useManusCore;
 
     std::vector<double> humanJointState, humanJointStateDeg;
 
@@ -143,6 +144,9 @@ bool ManusGlove::ManusGloveImpl::open(yarp::os::Searchable& config)
 
     bool isLocalHost = config.find("is_local_host").asBool();
     hostType = isLocalHost;
+
+    useManusCore = config.check("use_manus_core", yarp::os::Value(false)).asBool();
+    yInfo() << LogPrefix << "use_manus_core: " << (useManusCore ? "true" : "false");
 
     // Get Human Joint Names
     yarp::os::Bottle* jointListYarp;
@@ -268,7 +272,7 @@ bool ManusGlove::ManusGloveImpl::open(yarp::os::Searchable& config)
     yInfo() << LogPrefix << "publish_raw_data: " << (publishRawData ? "true" : "false");
 
 // TODO: Add a check if there is no glove connected!
-    if (!pGlove->Initialize(hostType))
+    if (!pGlove->Initialize(hostType, useManusCore))
     {
         yError() << LogPrefix << "Failed to initialize the ManusGloveHelper on the" << handSideLogPrefix << "hand.";
         return false;

--- a/ManusGlove/src/ManusGloveHelper.cpp
+++ b/ManusGlove/src/ManusGloveHelper.cpp
@@ -8,6 +8,8 @@
 
 #include <ManusGloveHelper.h>
 #include <unordered_map>
+#include <thread>
+#include <cstring>
 
 using namespace manusGlove;
 using namespace std;
@@ -36,7 +38,7 @@ ManusGloveHelper::~ManusGloveHelper()
     s_Instance = nullptr;
 }
 
-bool ManusGloveHelper::Initialize(bool p_hostType)
+bool ManusGloveHelper::Initialize(bool p_hostType, bool p_useManusCore)
 {
     if (s_Instance != this)
     {
@@ -46,7 +48,8 @@ bool ManusGloveHelper::Initialize(bool p_hostType)
     m_ShouldConnectLocally = p_hostType;
     // before we can use the SDK, some internal SDK bits need to be initialized.
     // however after initializing, the SDK is not yet connected to a host or doing anything network related just yet.
-    auto errorCode = CoreSdk_InitializeCore();
+    // Handle the platform specific initialization
+    auto errorCode = p_useManusCore ? CoreSdk_InitializeCore() : CoreSdk_InitializeIntegrated();
     if (errorCode != SDKReturnCode::SDKReturnCode_Success)
     {
         yError() << ManusGlove_LogPrefix << "SDK::Failed to initilize Core SDK. Error:" << errorCode;
@@ -1104,15 +1107,13 @@ std::string manusGlove::ManusGloveHelper::ConvertFingerJointTypeToString(FingerJ
 
 bool ManusGloveHelper::CopyString(char *const p_Target, const size_t p_MaxLengthThatWillFitInTarget, const std::string &p_Source)
 {
-    const errno_t t_CopyResult = strcpy_s(
-        p_Target,
-        p_MaxLengthThatWillFitInTarget,
-        p_Source.c_str());
-    if (t_CopyResult != 0)
+    if (p_Source.size() >= p_MaxLengthThatWillFitInTarget)
     {
-        yError() << ManusGlove_LogPrefix <<"Copying the string "<<p_Source.c_str()<< "resulted in the error " << t_CopyResult;
+        yError() << ManusGlove_LogPrefix << "Copying the string " << p_Source.c_str() << " failed: source exceeds target buffer size";
         return false;
     }
+    std::strncpy(p_Target, p_Source.c_str(), p_MaxLengthThatWillFitInTarget - 1);
+    p_Target[p_MaxLengthThatWillFitInTarget - 1] = '\0';
     return true;
 }
 

--- a/ManusGlove/src/ManusGloveHelper.cpp
+++ b/ManusGlove/src/ManusGloveHelper.cpp
@@ -1107,13 +1107,12 @@ std::string manusGlove::ManusGloveHelper::ConvertFingerJointTypeToString(FingerJ
 
 bool ManusGloveHelper::CopyString(char *const p_Target, const size_t p_MaxLengthThatWillFitInTarget, const std::string &p_Source)
 {
-    if (p_Source.size() >= p_MaxLengthThatWillFitInTarget)
+    if (p_Source.size() >= p_MaxLengthThatWillFitInTarget - 1)
     {
-        yError() << ManusGlove_LogPrefix << "Copying the string " << p_Source.c_str() << " failed: source exceeds target buffer size";
-        return false;
+            yError() << ManusGlove_LogPrefix << "Copying the string " << p_Source.c_str() << " failed: source exceeds target buffer size";
+    return false;
     }
-    std::strncpy(p_Target, p_Source.c_str(), p_MaxLengthThatWillFitInTarget - 1);
-    p_Target[p_MaxLengthThatWillFitInTarget - 1] = '\0';
+    std::strncpy(p_Target, p_Source.c_str(), p_MaxLengthThatWillFitInTarget);
     return true;
 }
 

--- a/cmake/FindManusSDK.cmake
+++ b/cmake/FindManusSDK.cmake
@@ -6,7 +6,12 @@ include(FindPackageHandleStandardArgs)
 set(MANUS_ROOT_DIR "$ENV{ManusGlove_DIR}" CACHE PATH "Folder containing the ManusSDK")
 
 find_path(MANUS_INCLUDE_DIR ManusSDK.h PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK/include)
-find_library(MANUS_LIBRARY ManusSDK PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK ManusSDK/lib)
+if(UNIX)
+  set(_manus_lib_name ManusSDK_integrated)
+else()
+  set(_manus_lib_name ManusSDK)
+endif()
+find_library(MANUS_LIBRARY ${_manus_lib_name} PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK ManusSDK/lib)
 
 find_package_handle_standard_args(ManusSDK DEFAULT_MSG MANUS_INCLUDE_DIR MANUS_LIBRARY)
 


### PR DESCRIPTION
This PR introduces the support for using the Manus device with Ubuntu 22.04.

In specific:
- We add the documentation on how to install it, standalone in a Conda env or with the superbuild.
- You cannot use Manus Core when you use Linux, so we add a parameter in the device `xml` which specifies whether to launch Manus Core or not.
- Use of a `std` function to allow compilation on diverse OS.
- The CMake now points to the correct SDK `.so` file, depending on the OS you are using.