### PR TITLE
Fix Manus Linux Install Documentation

### DIFF
--- a/ManusGlove/README.md
+++ b/ManusGlove/README.md
@@ -23,8 +23,8 @@ Summarizing, we only need to install the dependencies for Manus `Integrated`, no
 sudo apt-get update && sudo apt-get install -y build-essential git libtool libzmq3-dev libusb-1.0-0-dev zlib1g-dev libudev-dev gdb libncurses5-dev && sudo apt-get clean
 ```
 
-To allow connections to MANUS hardware you need to place the following file in `/etc/udev/rules.d/70-manus-hid-rules`.
-So, run `sudo nano /etc/udev/rules.d/70-manus-hid-rules` and put:
+To allow connections to MANUS hardware you need to place the following file in `/etc/udev/rules.d/70-manus-hid-rules.rules`.
+So, run `sudo nano /etc/udev/rules.d/70-manus-hid-rules.rules` and put:
 
 ```
 # HIDAPI/libusb
@@ -54,6 +54,8 @@ Export the environmental variables:
 
 ```bash
 export ManusGlove_DIR=<PATH_TO>/ManusSDK_v3.1.1/SDKClient_Linux
+```
+```bash
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ManusGlove_DIR$/ManusSDK/lib
 ```
 
@@ -72,7 +74,7 @@ make install
 ```
 
 ### Run the device
-After installation, the `xml` should now be installed in the correct `YARP_DATA_DIRS`.
+After installation, the device and the `yarprobotinterface` config `.xml` should now be installed in the correct `YARP_DATA_DIRS`.
 You can launch:
 ```bash
 yarprobotinterface --config ManusGlove.xml

--- a/cmake/FindManusSDK.cmake
+++ b/cmake/FindManusSDK.cmake
@@ -7,7 +7,7 @@ set(MANUS_ROOT_DIR "$ENV{ManusGlove_DIR}" CACHE PATH "Folder containing the Manu
 
 find_path(MANUS_INCLUDE_DIR ManusSDK.h PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK/include)
 if(UNIX)
-  set(_manus_lib_name ManusSDK_integrated)
+  set(_manus_lib_name ManusSDK_Integrated)
 else()
   set(_manus_lib_name ManusSDK)
 endif()


### PR DESCRIPTION
This PR fixes a couple of typos from #19 in the documentation to install the Manus device in Linux.