### PR TITLE
Enable automatic download of Manus SDK

### DIFF
--- a/.github/workflows/ci-conda-manus.yml
+++ b/.github/workflows/ci-conda-manus.yml
@@ -5,7 +5,15 @@ on:
     branches:
       - main
       - master
+    paths:
+      - 'ManusGlove/**'
+      - '!ManusGlove/**/*.md'
+      - '!ManusGlove/**/*.xml'
   pull_request:
+    paths:
+      - 'ManusGlove/**'
+      - '!ManusGlove/**/*.md'
+      - '!ManusGlove/**/*.xml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-conda-manus.yml
+++ b/.github/workflows/ci-conda-manus.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup MSVC toolchain (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Setup micromamba environment
         uses: mamba-org/setup-micromamba@v2
         with:
@@ -49,13 +53,25 @@ jobs:
 
       - name: Configure
         run: |
-          cmake -S . -B build \
-            -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="${CONDA_PREFIX}" \
-            -DYARP_DEVICE_MANUS_GLOVE_ENABLE=ON \
-            -DENABLE_MANUS_SDK_DOWNLOAD=ON \
-            -DMANUS_SDK_DOWNLOAD_VERSION="${{ matrix.manus_sdk_version }}"
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            cmake -S . -B build \
+              -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX="${CONDA_PREFIX}" \
+              -DCMAKE_C_COMPILER=cl \
+              -DCMAKE_CXX_COMPILER=cl \
+              -DYARP_DEVICE_MANUS_GLOVE_ENABLE=ON \
+              -DENABLE_MANUS_SDK_DOWNLOAD=ON \
+              -DMANUS_SDK_DOWNLOAD_VERSION="${{ matrix.manus_sdk_version }}"
+          else
+            cmake -S . -B build \
+              -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX="${CONDA_PREFIX}" \
+              -DYARP_DEVICE_MANUS_GLOVE_ENABLE=ON \
+              -DENABLE_MANUS_SDK_DOWNLOAD=ON \
+              -DMANUS_SDK_DOWNLOAD_VERSION="${{ matrix.manus_sdk_version }}"
+          fi
 
 
       - name: Build

--- a/.github/workflows/ci-conda-manus.yml
+++ b/.github/workflows/ci-conda-manus.yml
@@ -1,0 +1,65 @@
+name: manus-build
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-manus:
+    name: ${{ matrix.os }} / Manus SDK ${{ matrix.manus_sdk_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            manus_sdk_version: "2.5.1"
+          - os: ubuntu-latest
+            manus_sdk_version: "3.1.1"
+          - os: windows-latest
+            manus_sdk_version: "2.5.1"
+          - os: windows-latest
+            manus_sdk_version: "3.1.1"
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup micromamba environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: yarp-device-haptic-gloves-ci
+          cache-environment: true
+          create-args: >-
+            python=3.11
+            cmake
+            ninja
+            pkg-config
+            compilers
+            eigen
+            yarp
+            human-dynamics-estimation
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${CONDA_PREFIX}" \
+            -DYARP_DEVICE_MANUS_GLOVE_ENABLE=ON \
+            -DENABLE_MANUS_SDK_DOWNLOAD=ON \
+            -DMANUS_SDK_DOWNLOAD_VERSION="${{ matrix.manus_sdk_version }}"
+
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Install
+        run: cmake --install build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
 option(YARP_DEVICE_WEART_GLOVE_ENABLE "Flag that enables building WeArtGlove device" OFF)
 option(YARP_DEVICE_MANUS_GLOVE_ENABLE "Flag that enables building ManusGlove device" OFF)
 option(YARP_DEVICE_SENSE_GLOVE_ENABLE "Flag that enables building SenseGlove device" OFF)
+option(ENABLE_MANUS_SDK_DOWNLOAD "Download and extract Manus SDK automatically. Overrides ManusGlove_DIR" OFF)
 
 # Flag to enable WeArtGloves device
 if(YARP_DEVICE_WEART_GLOVE_ENABLE)

--- a/ManusGlove/CMakeLists.txt
+++ b/ManusGlove/CMakeLists.txt
@@ -64,6 +64,13 @@ yarp_install(TARGETS ${ManusGloveDevName}
              YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
              )
 
+if(ENABLE_MANUS_SDK_DOWNLOAD)
+    get_target_property(_manus_sdk_lib_path ManusSDK::ManusSDK IMPORTED_LOCATION)
+    install(FILES "${_manus_sdk_lib_path}"
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT runtime)
+endif()
+
 set (MAIN_XML_FILES conf/ManusGlove.xml)
 
 set (HANDS_XML_FILES conf/ManusGlove/Right.xml

--- a/ManusGlove/CMakeLists.txt
+++ b/ManusGlove/CMakeLists.txt
@@ -11,6 +11,10 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 set(ManusGloveDevName "ManusGlove")
 
+if(ENABLE_MANUS_SDK_DOWNLOAD)
+    include(DownloadManusSDK)
+endif()
+
 find_package(ManusSDK REQUIRED)
 
 # Export all symbols in Windows

--- a/ManusGlove/README.md
+++ b/ManusGlove/README.md
@@ -50,17 +50,44 @@ Now you can run:
 
 ### Install the device
 
-Export the environmental variables:
+You can build ManusGlove in two ways.
+
+1. Automatic SDK download (recommended)
+
+No manual SDK setup is needed. CMake downloads and prepares the SDK for you.
+
+```bash
+mkdir build && cd build
+cmake .. \
+	-DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+	-DYARP_DEVICE_MANUS_GLOVE_ENABLE=ON \
+	-DENABLE_MANUS_SDK_DOWNLOAD=ON
+```
+
+The default downloaded version is `3.1.1`.
+If you want a different version, add:
+
+```bash
+-DMANUS_SDK_DOWNLOAD_VERSION=<version>
+```
+
+Examples:
+
+```bash
+-DMANUS_SDK_DOWNLOAD_VERSION=3.1.1
+-DMANUS_SDK_DOWNLOAD_VERSION=2.5.1
+```
+
+2. Manual SDK setup
+
+If you prefer to provide the SDK yourself, export:
 
 ```bash
 export ManusGlove_DIR=<PATH_TO>/ManusSDK_v3.1.1/SDKClient_Linux
 ```
-```bash
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ManusGlove_DIR$/ManusSDK/lib
-```
 
-Run `cmake`, make sure to set the right `CMAKE_INSTALL_PREFIX`. If you are using the `superbuild`, point to the superbuild install prefix. 
-If you are using a conda environment, you can use: 
+Then configure without the download flag:
+
 ```bash
 mkdir build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DYARP_DEVICE_MANUS_GLOVE_ENABLE=ON
@@ -75,6 +102,15 @@ make install
 
 ### Run the device
 After installation, the device and the `yarprobotinterface` config `.xml` should now be installed in the correct `YARP_DATA_DIRS`.
+If you installed in a non-system prefix, export:
+
+```bash
+export YARP_DATA_DIRS=$YARP_DATA_DIRS:<INSTALL_PREFIX>/share/yarp
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<INSTALL_PREFIX>/lib
+```
+
+The install step also places the ManusSDK runtime libraries in `<INSTALL_PREFIX>/lib`.
+
 You can launch:
 ```bash
 yarprobotinterface --config ManusGlove.xml

--- a/ManusGlove/README.md
+++ b/ManusGlove/README.md
@@ -50,11 +50,13 @@ Now you can run:
 
 ### Install the device
 
+When running the `cmake` commands below, make sure to set the right `CMAKE_INSTALL_PREFIX`. If you are using the `robotology-superbuild`, point it to the superbuild install prefix.
+If you are using a conda environment, you can use $CONDA_PREFIX as the install prefix (as in the examples below).
+
 You can build ManusGlove in two ways.
 
 1. Automatic SDK download (recommended)
 
-No manual SDK setup is needed. CMake downloads and prepares the SDK for you.
 
 ```bash
 mkdir build && cd build
@@ -78,15 +80,17 @@ Examples:
 -DMANUS_SDK_DOWNLOAD_VERSION=2.5.1
 ```
 
+If you downloaded the SDK during the build, the install step also places the ManusSDK runtime libraries in `<INSTALL_PREFIX>/lib`.
+
+
 2. Manual SDK setup
 
 If you prefer to provide the SDK yourself, export:
 
 ```bash
 export ManusGlove_DIR=<PATH_TO>/ManusSDK_v3.1.1/SDKClient_Linux
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ManusGlove_DIR$/ManusSDK/lib
 ```
-
-Then configure without the download flag:
 
 ```bash
 mkdir build && cd build
@@ -100,8 +104,6 @@ make -j
 make install
 ```
 
-### Run the device
-After installation, the device and the `yarprobotinterface` config `.xml` should now be installed in the correct `YARP_DATA_DIRS`.
 If you installed in a non-system prefix, export:
 
 ```bash
@@ -109,8 +111,8 @@ export YARP_DATA_DIRS=$YARP_DATA_DIRS:<INSTALL_PREFIX>/share/yarp
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<INSTALL_PREFIX>/lib
 ```
 
-The install step also places the ManusSDK runtime libraries in `<INSTALL_PREFIX>/lib`.
-
+### Run the device
+After installation, the device and the `yarprobotinterface` config `.xml` should now be installed in the correct `YARP_DATA_DIRS`.
 You can launch:
 ```bash
 yarprobotinterface --config ManusGlove.xml

--- a/cmake/DownloadManusSDK.cmake
+++ b/cmake/DownloadManusSDK.cmake
@@ -5,7 +5,7 @@ set(_manus_sdk_version "3.1.1")
 set(_manus_sdk_archive_name "MANUS_Core_${_manus_sdk_version}_SDK.zip")
 set(_manus_sdk_url "https://static.manus-meta.com/resources/manus_core_3/sdk/${_manus_sdk_archive_name}")
 
-set(_manus_sdk_base_dir "${CMAKE_BINARY_DIR}/manus-sdk")
+set(_manus_sdk_base_dir "${CMAKE_BINARY_DIR}")
 set(_manus_sdk_zip_path "${_manus_sdk_base_dir}/${_manus_sdk_archive_name}")
 set(_manus_sdk_extract_dir "${_manus_sdk_base_dir}")
 
@@ -20,7 +20,7 @@ set(_manus_sdk_header_marker "${_manus_sdk_client_dir}/ManusSDK/include/ManusSDK
 
 file(MAKE_DIRECTORY "${_manus_sdk_base_dir}")
 
-if(NOT EXISTS "${_manus_sdk_zip_path}")
+if(NOT EXISTS "${_manus_sdk_header_marker}")
   message(STATUS "Downloading Manus SDK ${_manus_sdk_version} from ${_manus_sdk_url}")
   file(DOWNLOAD
     "${_manus_sdk_url}"
@@ -34,9 +34,7 @@ if(NOT EXISTS "${_manus_sdk_zip_path}")
     list(GET _manus_sdk_download_status 1 _manus_sdk_download_message)
     message(FATAL_ERROR "Failed to download Manus SDK: ${_manus_sdk_download_message}")
   endif()
-endif()
 
-if(NOT EXISTS "${_manus_sdk_header_marker}")
   message(STATUS "Extracting Manus SDK archive ${_manus_sdk_zip_path}")
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E tar xf "${_manus_sdk_zip_path}"
@@ -47,6 +45,8 @@ if(NOT EXISTS "${_manus_sdk_header_marker}")
   if(NOT _manus_sdk_extract_result EQUAL 0)
     message(FATAL_ERROR "Failed to extract Manus SDK archive: ${_manus_sdk_zip_path}")
   endif()
+
+  file(REMOVE "${_manus_sdk_zip_path}")
 endif()
 
 set(MANUS_ROOT_DIR

--- a/cmake/DownloadManusSDK.cmake
+++ b/cmake/DownloadManusSDK.cmake
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
-set(_manus_sdk_version "3.1.1")
-set(_manus_sdk_archive_name "MANUS_Core_${_manus_sdk_version}_SDK.zip")
+set(MANUS_SDK_DOWNLOAD_VERSION "3.1.1" CACHE STRING "Manus SDK version to download")
+set(_manus_sdk_archive_name "MANUS_Core_${MANUS_SDK_DOWNLOAD_VERSION}_SDK.zip")
 set(_manus_sdk_url "https://static.manus-meta.com/resources/manus_core_3/sdk/${_manus_sdk_archive_name}")
 
 set(_manus_sdk_base_dir "${CMAKE_BINARY_DIR}")
@@ -10,9 +10,9 @@ set(_manus_sdk_zip_path "${_manus_sdk_base_dir}/${_manus_sdk_archive_name}")
 set(_manus_sdk_extract_dir "${_manus_sdk_base_dir}")
 
 if(UNIX)
-  set(_manus_sdk_client_dir "${_manus_sdk_extract_dir}/ManusSDK_v${_manus_sdk_version}/SDKClient_Linux")
+  set(_manus_sdk_client_dir "${_manus_sdk_extract_dir}/ManusSDK_v${MANUS_SDK_DOWNLOAD_VERSION}/SDKClient_Linux")
 else()
-  set(_manus_sdk_client_dir "${_manus_sdk_extract_dir}/ManusSDK_v${_manus_sdk_version}/SDKClient_Windows")
+  set(_manus_sdk_client_dir "${_manus_sdk_extract_dir}/ManusSDK_v${MANUS_SDK_DOWNLOAD_VERSION}/SDKClient_Windows")
 endif()
 
 # Header location is used as extraction marker so repeated configure runs are idempotent.
@@ -21,7 +21,7 @@ set(_manus_sdk_header_marker "${_manus_sdk_client_dir}/ManusSDK/include/ManusSDK
 file(MAKE_DIRECTORY "${_manus_sdk_base_dir}")
 
 if(NOT EXISTS "${_manus_sdk_header_marker}")
-  message(STATUS "Downloading Manus SDK ${_manus_sdk_version} from ${_manus_sdk_url}")
+  message(STATUS "Downloading Manus SDK ${MANUS_SDK_DOWNLOAD_VERSION} from ${_manus_sdk_url}")
   file(DOWNLOAD
     "${_manus_sdk_url}"
     "${_manus_sdk_zip_path}"
@@ -54,4 +54,5 @@ set(MANUS_ROOT_DIR
     CACHE PATH "Folder containing the ManusSDK"
     FORCE)
 
-message(STATUS "Using Manus SDK from ${MANUS_ROOT_DIR}")
+message(STATUS "Downloaded Manus SDK ${MANUS_SDK_DOWNLOAD_VERSION} to ${MANUS_ROOT_DIR}")
+message(STATUS "Using Manus SDK ${MANUS_SDK_DOWNLOAD_VERSION} from ${MANUS_ROOT_DIR}")

--- a/cmake/DownloadManusSDK.cmake
+++ b/cmake/DownloadManusSDK.cmake
@@ -3,7 +3,11 @@
 
 set(MANUS_SDK_DOWNLOAD_VERSION "3.1.1" CACHE STRING "Manus SDK version to download")
 set(_manus_sdk_archive_name "MANUS_Core_${MANUS_SDK_DOWNLOAD_VERSION}_SDK.zip")
-set(_manus_sdk_url "https://static.manus-meta.com/resources/manus_core_3/sdk/${_manus_sdk_archive_name}")
+if(MANUS_SDK_DOWNLOAD_VERSION VERSION_LESS "3.0.0")
+  set(_manus_sdk_url "https://static.manus-meta.com/resources/manus_core_2/sdk/${_manus_sdk_archive_name}")
+else()
+  set(_manus_sdk_url "https://static.manus-meta.com/resources/manus_core_3/sdk/${_manus_sdk_archive_name}")
+endif()
 
 set(_manus_sdk_base_dir "${CMAKE_BINARY_DIR}")
 set(_manus_sdk_zip_path "${_manus_sdk_base_dir}/${_manus_sdk_archive_name}")
@@ -46,7 +50,29 @@ if(NOT EXISTS "${_manus_sdk_header_marker}")
     message(FATAL_ERROR "Failed to extract Manus SDK archive: ${_manus_sdk_zip_path}")
   endif()
 
-  file(REMOVE "${_manus_sdk_zip_path}")
+  if(MANUS_SDK_DOWNLOAD_VERSION VERSION_LESS "3.0.0")
+    set(_manus_sdk_nested_zip_path "${_manus_sdk_base_dir}/SDKClient.zip")
+    set(_manus_sdk_nested_extract_dir "${_manus_sdk_extract_dir}/ManusSDK_v${MANUS_SDK_DOWNLOAD_VERSION}")
+
+    if(NOT EXISTS "${_manus_sdk_nested_zip_path}")
+      message(FATAL_ERROR "Expected nested SDKClient.zip for Manus SDK ${MANUS_SDK_DOWNLOAD_VERSION}, but none was found.")
+    endif()
+
+    file(MAKE_DIRECTORY "${_manus_sdk_nested_extract_dir}")
+
+    message(STATUS "Extracting nested Manus SDK archive ${_manus_sdk_nested_zip_path}")
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E tar xf "${_manus_sdk_nested_zip_path}"
+      WORKING_DIRECTORY "${_manus_sdk_nested_extract_dir}"
+      RESULT_VARIABLE _manus_sdk_nested_extract_result
+    )
+
+    if(NOT _manus_sdk_nested_extract_result EQUAL 0)
+      message(FATAL_ERROR "Failed to extract nested Manus SDK archive: ${_manus_sdk_nested_zip_path}")
+    endif()
+  endif()
+
+  #file(REMOVE "${_manus_sdk_zip_path}")
 endif()
 
 set(MANUS_ROOT_DIR

--- a/cmake/DownloadManusSDK.cmake
+++ b/cmake/DownloadManusSDK.cmake
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+set(_manus_sdk_version "3.1.1")
+set(_manus_sdk_archive_name "MANUS_Core_${_manus_sdk_version}_SDK.zip")
+set(_manus_sdk_url "https://static.manus-meta.com/resources/manus_core_3/sdk/${_manus_sdk_archive_name}")
+
+set(_manus_sdk_base_dir "${CMAKE_BINARY_DIR}/manus-sdk")
+set(_manus_sdk_zip_path "${_manus_sdk_base_dir}/${_manus_sdk_archive_name}")
+set(_manus_sdk_extract_dir "${_manus_sdk_base_dir}")
+
+if(UNIX)
+  set(_manus_sdk_client_dir "${_manus_sdk_extract_dir}/ManusSDK_v${_manus_sdk_version}/SDKClient_Linux")
+else()
+  set(_manus_sdk_client_dir "${_manus_sdk_extract_dir}/ManusSDK_v${_manus_sdk_version}/SDKClient_Windows")
+endif()
+
+# Header location is used as extraction marker so repeated configure runs are idempotent.
+set(_manus_sdk_header_marker "${_manus_sdk_client_dir}/ManusSDK/include/ManusSDK.h")
+
+file(MAKE_DIRECTORY "${_manus_sdk_base_dir}")
+
+if(NOT EXISTS "${_manus_sdk_zip_path}")
+  message(STATUS "Downloading Manus SDK ${_manus_sdk_version} from ${_manus_sdk_url}")
+  file(DOWNLOAD
+    "${_manus_sdk_url}"
+    "${_manus_sdk_zip_path}"
+    SHOW_PROGRESS
+    STATUS _manus_sdk_download_status
+  )
+
+  list(GET _manus_sdk_download_status 0 _manus_sdk_download_code)
+  if(NOT _manus_sdk_download_code EQUAL 0)
+    list(GET _manus_sdk_download_status 1 _manus_sdk_download_message)
+    message(FATAL_ERROR "Failed to download Manus SDK: ${_manus_sdk_download_message}")
+  endif()
+endif()
+
+if(NOT EXISTS "${_manus_sdk_header_marker}")
+  message(STATUS "Extracting Manus SDK archive ${_manus_sdk_zip_path}")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xf "${_manus_sdk_zip_path}"
+    WORKING_DIRECTORY "${_manus_sdk_base_dir}"
+    RESULT_VARIABLE _manus_sdk_extract_result
+  )
+
+  if(NOT _manus_sdk_extract_result EQUAL 0)
+    message(FATAL_ERROR "Failed to extract Manus SDK archive: ${_manus_sdk_zip_path}")
+  endif()
+endif()
+
+set(MANUS_ROOT_DIR
+    "${_manus_sdk_client_dir}"
+    CACHE PATH "Folder containing the ManusSDK"
+    FORCE)
+
+message(STATUS "Using Manus SDK from ${MANUS_ROOT_DIR}")

--- a/cmake/FindManusSDK.cmake
+++ b/cmake/FindManusSDK.cmake
@@ -5,13 +5,13 @@ include(FindPackageHandleStandardArgs)
 
 set(MANUS_ROOT_DIR "$ENV{ManusGlove_DIR}" CACHE PATH "Folder containing the ManusSDK")
 
-find_path(MANUS_INCLUDE_DIR ManusSDK.h PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK/include)
+find_path(MANUS_INCLUDE_DIR ManusSDK.h PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK/include NO_DEFAULT_PATH)
 if(UNIX)
   set(_manus_lib_name ManusSDK_Integrated)
 else()
   set(_manus_lib_name ManusSDK)
 endif()
-find_library(MANUS_LIBRARY ${_manus_lib_name} PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK ManusSDK/lib)
+find_library(MANUS_LIBRARY ${_manus_lib_name} PATHS ${MANUS_ROOT_DIR} PATH_SUFFIXES ManusSDK ManusSDK/lib NO_DEFAULT_PATH)
 
 find_package_handle_standard_args(ManusSDK DEFAULT_MSG MANUS_INCLUDE_DIR MANUS_LIBRARY)
 


### PR DESCRIPTION
This pull request introduces an automatic Manus SDK download feature for the ManusGlove device. The build system and documentation have been updated to support both automatic and manual SDK installation, and a new CI workflow is added to test builds with multiple SDK versions and platforms.

**CMake changes:**

* Updated `FindManusSDK.cmake` to use `NO_DEFAULT_PATH` for finding the SDK, ensuring that only explicitly provided or downloaded SDK paths are used, avoiding accidental use of system-wide installations.
* When the SDK is downloaded, runtime libraries are installed at the install path as well