### PR TITLE
Fix linking issue installing in another folder

### DIFF
--- a/cmake/FindManusSDK.cmake
+++ b/cmake/FindManusSDK.cmake
@@ -17,27 +17,19 @@ find_package_handle_standard_args(ManusSDK DEFAULT_MSG MANUS_INCLUDE_DIR MANUS_L
 
 if(ManusSDK_FOUND)
     if(NOT TARGET ManusSDK::ManusSDK)
-      if(UNIX)
-        # The prebuilt Manus SDK shared library ships without a DT_SONAME. By
-        # default CMake links imported libraries by full path, which makes the
-        # linker bake that (build-relative) path into the consumer's DT_NEEDED
-        # entry, breaking it at runtime. IMPORTED_NO_SONAME makes CMake link via
-        # -L<dir> -l<name> so the linker records only the basename
-        # (libManusSDK_Integrated.so), resolved at runtime through the
-        # consumer's RPATH ($ORIGIN/../lib). Note: this property is only honored
-        # for targets CMake treats as shared libraries, hence SHARED IMPORTED
-        # (not UNKNOWN IMPORTED).
-        add_library(ManusSDK::ManusSDK SHARED IMPORTED)
-        set_target_properties(ManusSDK::ManusSDK PROPERTIES
-          INTERFACE_INCLUDE_DIRECTORIES "${MANUS_INCLUDE_DIR}"
-          IMPORTED_LOCATION "${MANUS_LIBRARY}"
-          IMPORTED_NO_SONAME TRUE)
-      else()
-        add_library(ManusSDK::ManusSDK UNKNOWN IMPORTED)
-        set_target_properties(ManusSDK::ManusSDK PROPERTIES
-          INTERFACE_INCLUDE_DIRECTORIES "${MANUS_INCLUDE_DIR}")
-        set_property(TARGET ManusSDK::ManusSDK APPEND PROPERTY
-          IMPORTED_LOCATION "${MANUS_LIBRARY}")
-      endif()
+      # The prebuilt Manus SDK shared library ships without a DT_SONAME. By
+      # default CMake links imported libraries by full path, which makes the
+      # linker bake that (build-relative) path into the consumer's DT_NEEDED
+      # entry, breaking it at runtime. IMPORTED_NO_SONAME makes CMake link via
+      # -L<dir> -l<name> so the linker records only the basename
+      # (libManusSDK_Integrated.so), resolved at runtime through the
+      # consumer's RPATH ($ORIGIN/../lib). Note: this property is only honored
+      # for targets CMake treats as shared libraries, hence SHARED IMPORTED
+      # (not UNKNOWN IMPORTED).
+      add_library(ManusSDK::ManusSDK SHARED IMPORTED)
+      set_target_properties(ManusSDK::ManusSDK PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${MANUS_INCLUDE_DIR}"
+        IMPORTED_LOCATION "${MANUS_LIBRARY}"
+        IMPORTED_NO_SONAME TRUE)
     endif()
 endif()

--- a/cmake/FindManusSDK.cmake
+++ b/cmake/FindManusSDK.cmake
@@ -17,10 +17,27 @@ find_package_handle_standard_args(ManusSDK DEFAULT_MSG MANUS_INCLUDE_DIR MANUS_L
 
 if(ManusSDK_FOUND)
     if(NOT TARGET ManusSDK::ManusSDK)
-      add_library(ManusSDK::ManusSDK UNKNOWN IMPORTED)
-      set_target_properties(ManusSDK::ManusSDK PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${MANUS_INCLUDE_DIR}")
-      set_property(TARGET ManusSDK::ManusSDK APPEND PROPERTY
-        IMPORTED_LOCATION "${MANUS_LIBRARY}")
+      if(UNIX)
+        # The prebuilt Manus SDK shared library ships without a DT_SONAME. By
+        # default CMake links imported libraries by full path, which makes the
+        # linker bake that (build-relative) path into the consumer's DT_NEEDED
+        # entry, breaking it at runtime. IMPORTED_NO_SONAME makes CMake link via
+        # -L<dir> -l<name> so the linker records only the basename
+        # (libManusSDK_Integrated.so), resolved at runtime through the
+        # consumer's RPATH ($ORIGIN/../lib). Note: this property is only honored
+        # for targets CMake treats as shared libraries, hence SHARED IMPORTED
+        # (not UNKNOWN IMPORTED).
+        add_library(ManusSDK::ManusSDK SHARED IMPORTED)
+        set_target_properties(ManusSDK::ManusSDK PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${MANUS_INCLUDE_DIR}"
+          IMPORTED_LOCATION "${MANUS_LIBRARY}"
+          IMPORTED_NO_SONAME TRUE)
+      else()
+        add_library(ManusSDK::ManusSDK UNKNOWN IMPORTED)
+        set_target_properties(ManusSDK::ManusSDK PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${MANUS_INCLUDE_DIR}")
+        set_property(TARGET ManusSDK::ManusSDK APPEND PROPERTY
+          IMPORTED_LOCATION "${MANUS_LIBRARY}")
+      endif()
     endif()
 endif()


### PR DESCRIPTION
I tried building and installing in a shared workspace and the process went smoothly.
However, I was getting this issue at runtime:
```
[ERROR] |yarp.os.YarpPluginSettings| Error while opening /home/mmastrogiuseppe/gbmono/install/lib/yarp/ManusGlove.so: 
../ManusSDK_v3.1.1/SDKClient_Linux/ManusSDK/lib/libManusSDK_Integrated.so: cannot open shared object file: No such file or directory
```

It seems cmake was linking with a relative path for some reason. Solution by Claude:

**Error:** The prebuilt `libManusSDK_Integrated.so` has no `DT_SONAME`. When CMake links an imported library by its full path, the linker copies that path verbatim into `ManusGlove.so`'s `DT_NEEDED`. Since the build runs in a subdir, it baked in a build-relative path (`../ManusSDK_v3.1.1/.../libManusSDK_Integrated.so`) that doesn't exist at runtime.

**Fix:** Declare the import as `SHARED IMPORTED` + `IMPORTED_NO_SONAME TRUE`. This makes CMake link with `-L<dir> -l<name>` instead of the full path, so the linker records just the basename `libManusSDK_Integrated.so` — which the device's existing RPATH (`$ORIGIN/../lib`) resolves. (`SHARED` is required; the property is ignored on `UNKNOWN IMPORTED`.)